### PR TITLE
feat!: [SIW-429] Signed JWT interface improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,20 @@ if isValid {
 ### Create and sign a JWT with a JWS
 
 ```js
-// Create unsecured jwt
-let jwtToSign = new SignJWT({ metadata: 'demo' })
-  .setProtectedHeader({ alg: 'ES256', typ: 'JWT' })
+// Define a cryptographic context suitable for the application needs
+const crypto: CryptoContext = userDefinedCryptoContext();
+
+// Create jwt
+const jwt = new SignJWT(crypto)
+  .setPayload({ metadata: 'demo' })
+  .setProtectedHeader({ typ: 'JWT' })
   .setAudience('demo')
   .setExpirationTime('1h')
-  .setIssuedAt()
-  .toSign();
+  .setIssuedAt();
 
-// Create signature
-let signature = signWithMyCustomFunction(jwtToSign);
+// get signed jwt
+const signedJwt = jwt.signed();
 
-// Create signed JWT
-let signedJwt = await SignJWT.appendSignature(jwtToSign, signature);
-
-console.log(signedJwt)
 ```
 
 ### JWK thumbprint

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ A fast implementation of `jwt` module.
 Provides much greater performance for decoding, signing and verifying JWTs!
 
 🚀 Use only native functions via the following libraries:
+
 - 🤖 [nimbus-jose-jwt](https://github.com/felx/nimbus-jose-jwt/) on Android
 - 📱 [JOSESwift](https://github.com/airsidemobile/JOSESwift/) on iOS
-
-
-
 
 ## Installation
 
@@ -26,7 +24,7 @@ For detailed documentation go [here](/docs/modules/index.md)
 import { decode } from '@pagopa/io-react-native-jwt';
 
 // ...
-const jwt = "eyJ0eXAiOiJlbnRpdHktc3.....";
+const jwt = 'eyJ0eXAiOiJlbnRpdHktc3.....';
 const result = await decode(jwt);
 console.log(result);
 ```
@@ -38,18 +36,18 @@ import { verify } from '@pagopa/io-react-native-jwt';
 
 // ...
 const pubJwk = {
-    crv: 'P-256',
-    kty: 'EC',
-    x: 'qrJrj.....',
-    y: '1H0cW.....',
-  };
-const jwt = "eyJ0eXAiOiJlbnRpdHktc3.....";
+  crv: 'P-256',
+  kty: 'EC',
+  x: 'qrJrj.....',
+  y: '1H0cW.....',
+};
+const jwt = 'eyJ0eXAiOiJlbnRpdHktc3.....';
 const options = {
-    typ: 'jwt',
-    requiredClaims: ['iss', 'sub'],
-}
-const {protectedHeader, payload} = await verify(jwt, pubJwk, options);
-console.log(protectedHeader, payload)
+  typ: 'jwt',
+  requiredClaims: ['iss', 'sub'],
+};
+const { protectedHeader, payload } = await verify(jwt, pubJwk, options);
+console.log(protectedHeader, payload);
 ```
 
 ### Verify JWT with JWKS fetched from remote URL
@@ -61,10 +59,10 @@ import { verify, getRemoteJWKSet } from '@pagopa/io-react-native-jwt';
 const wellKnownUrl = 'https://example.com/.well-known/openid-federation';
 const jwks = await getRemoteJWKSet(wellKnownUrl);
 
-const jwt = "eyJ0eXAiOiJlbnRpdHktc3.....";
+const jwt = 'eyJ0eXAiOiJlbnRpdHktc3.....';
 
-const {protectedHeader, payload} = await verify(jwt, jwks);
-console.log(protectedHeader, payload)
+const { protectedHeader, payload } = await verify(jwt, jwks);
+console.log(protectedHeader, payload);
 ```
 
 ### Verify a JWT signature (JWS)
@@ -105,8 +103,7 @@ const jwt = new SignJWT(crypto)
   .setIssuedAt();
 
 // get signed jwt
-const signedJwt = jwt.signed();
-
+const signedJwt = jwt.sign();
 ```
 
 ### JWK thumbprint
@@ -116,13 +113,13 @@ import { thumbprint } from '@pagopa/io-react-native-jwt';
 
 // ...
 const pubJwk = {
-    crv: 'P-256',
-    kty: 'EC',
-    x: 'qrJrj.....',
-    y: '1H0cW.....',
-  };
+  crv: 'P-256',
+  kty: 'EC',
+  x: 'qrJrj.....',
+  y: '1H0cW.....',
+};
 const thumbprint = await thumbprint(pubJwk);
-console.log(thumbprint)
+console.log(thumbprint);
 ```
 
 ##  Signature format

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -60,7 +60,7 @@ export default function App() {
         iss: 'PagoPa',
       })
       .setProtectedHeader({ typ: 'JWT' })
-      .signed();
+      .sign();
 
     verifyJwtSignature(signedJwt, pk);
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-jwt",
-  "version": "0.6.4",
+  "version": "1.0.0",
   "description": "Native support for JWT",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/__tests__/algorithms.test.ts
+++ b/src/__tests__/algorithms.test.ts
@@ -1,0 +1,39 @@
+import { JOSENotSupported } from '../utils/errors';
+import { getAlgFromKey, supportedAlgorithms } from '../algorithms';
+
+describe('getAlgFromKey', () => {
+  const allSupportedRsaKeys = supportedAlgorithms.map((alg) => ({
+    kty: 'RSA',
+    alg,
+  }));
+  it.each(allSupportedRsaKeys.map((k) => [k]))(
+    'should use the given algorithm for RSA keys if the algorithm is supported (%o)',
+    (key) => {
+      expect(getAlgFromKey(key)).toBe(key.alg);
+    }
+  );
+
+  it.each`
+    key                            | expected
+    ${{ kty: 'EC', crv: 'P-256' }} | ${'ES256'}
+    ${{ kty: 'EC', crv: 'P-384' }} | ${'ES384'}
+    ${{ kty: 'EC', crv: 'P-512' }} | ${'ES512'}
+    ${{ kty: 'EC', crv: 'P-521' }} | ${'ES512'}
+  `(
+    'should get correct algorithm for elliptic keys ($key.crv)',
+    ({ key, expected }) => {
+      expect(getAlgFromKey(key)).toBe(expected);
+    }
+  );
+
+  it.each`
+    scenario                  | key
+    ${'unsupported key type'} | ${{ kty: 'unsupported' }}
+    ${'unsupported crv'}      | ${{ kty: 'EC', crv: 'unsupported' }}
+    ${'unsupported alg'}      | ${{ kty: 'RSA', alg: 'unsupported' }}
+    ${'bad rsa'}              | ${{ kty: 'RSA', crv: 'P-256' }}
+    ${'bad ec'}               | ${{ kty: 'EC', alg: 'RS256' }}
+  `('should fail on invalid or unsupported key ($scenario)', ({ key }) => {
+    expect(() => getAlgFromKey(key)).toThrow(JOSENotSupported);
+  });
+});

--- a/src/__tests__/jwks.ts
+++ b/src/__tests__/jwks.ts
@@ -30,28 +30,28 @@ const jwks: JWK[] = [
 describe('getJwkFromHeader', function () {
   it('it should return the correct JWK with ES256', async () => {
     const header = {
-      alg: 'ES256',
+      alg: 'ES256' as const,
       kid: '#EC2',
     };
     expect(getJwkFromHeader(header, jwks)).toBe(jwks[1]);
   });
   it('it should return the correct JWK with RS256', async () => {
     const header = {
-      alg: 'RS256',
+      alg: 'RS256' as const,
       kid: '#RSA1',
     };
     expect(getJwkFromHeader(header, jwks)).toBe(jwks[2]);
   });
   it('it should fail with wrong kid', async () => {
     const header = {
-      alg: 'ES256',
+      alg: 'ES256' as const,
       kid: '#RSA1',
     };
     expect(() => getJwkFromHeader(header, jwks)).toThrowError(JWKNotFound);
   });
   it('it should fail with an invalid header', async () => {
     const header = {
-      alg: 'ES256',
+      alg: 'ES256' as const,
     };
     expect(() => getJwkFromHeader(header, jwks)).toThrowError(JWKNotFound);
   });

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -1,6 +1,5 @@
-import type { CompactJWSHeaderParameters, JWTPayload } from '../types';
+import type { JWTPayload } from '../types';
 import { SignJWT } from '../jwt/sign';
-import { JOSENotSupported, JWSInvalid } from '../utils/errors';
 
 const jwtPayload: JWTPayload = {
   iss: 'demo',
@@ -9,37 +8,74 @@ const jwtPayload: JWTPayload = {
   exp: 1706742000,
 };
 
-const jwtHeader: CompactJWSHeaderParameters = {
+const jwtHeader = {
   typ: 'jwt',
-  kid: 'EC#1',
-  alg: 'ES256',
 };
 
-const signature =
-  '6wA0M6rNYNSFN_EylzMA6ElAibW7FVSZyoLNEkHU5c_RKuiNenT08YIMvbysYautLZotUedEMP5xCyNpY34x6Q';
+const pk0 = {
+  crv: 'P-256',
+  kty: 'EC',
+  x: '4HNptI-xr2pjyRJKGMnz4WmdnQD_uJSq4R95Nj98b44',
+  y: 'LIZnSB39vFJhYgS3k7jXE4r3-CoGFQwZtPBIRqpNlrg',
+  kid: '#EC2',
+};
 
-let toSign = new SignJWT()
-  .setPayload(jwtPayload)
-  .setProtectedHeader(jwtHeader)
-  .toSign();
+const pk1 = {
+  kty: 'RSA',
+  e: 'AQAB',
+  use: 'sig',
+  kid: '#RSA1',
+  alg: 'RS256',
+  n: 'gwZ0FqSsW18PufbHZBXijW4nEdIo5FLAt9MjDjzwCL9VXP4f9qs0c1mhzlgQtQ5GssqxkY1-APa1DA4LdhCaYzI5rKpRRPIqqgiTUErVtf2P36d0ZmjBdOQXumyGZjYSkQYSuMeTLVu_WZ9wg9O2V37DEcAqFwsbLVse1dvjv1Rz9nI_DoiXKMY7RozL560SK3V1gitPN1rx56Uc02t5eC6inmxSpZgs9Dhs61ntm0r6LVgRHmL0Mq8Q7waGqP9LSnA9t1E4Nn5CWvAkaqb2X6VsRJZBdkoxkPXwxi-PETfenVQk8A11Ppd9QFTlST8Tu5i5vZZkbuMDgNyH3ooAhQ',
+};
+
+const mockCrypto = {
+  getPublicKey: jest.fn(async () => pk0 /* just the first */),
+  getSignature: jest.fn(
+    async () =>
+      '6wA0M6rNYNSFN_EylzMA6ElAibW7FVSZyoLNEkHU5c_RKuiNenT08YIMvbysYautLZotUedEMP5xCyNpY34x6Q'
+  ),
+};
 
 describe('Sign JWT', function () {
   it('it should be signed correctly', async () => {
-    let signedJwt = await SignJWT.appendSignature(toSign, signature);
+    const signedJwt = await new SignJWT(mockCrypto)
+      .setPayload(jwtPayload)
+      .setProtectedHeader(jwtHeader)
+      .signed();
+
     expect(signedJwt).toBe(
-      'eyJ0eXAiOiJqd3QiLCJraWQiOiJFQyMxIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiJkZW1vIiwic3ViIjoiZGVtbyIsImlhdCI6MTY3NTIwNjAwMCwiZXhwIjoxNzA2NzQyMDAwfQ.6wA0M6rNYNSFN_EylzMA6ElAibW7FVSZyoLNEkHU5c_RKuiNenT08YIMvbysYautLZotUedEMP5xCyNpY34x6Q'
+      'eyJ0eXAiOiJqd3QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkZW1vIiwic3ViIjoiZGVtbyIsImlhdCI6MTY3NTIwNjAwMCwiZXhwIjoxNzA2NzQyMDAwfQ.6wA0M6rNYNSFN_EylzMA6ElAibW7FVSZyoLNEkHU5c_RKuiNenT08YIMvbysYautLZotUedEMP5xCyNpY34x6Q'
     );
   });
-  it('it should fails with invalid alg', async () => {
-    expect(() =>
-      new SignJWT()
+
+  it('it should ignore a passed alg', async () => {
+    const signed = await new SignJWT(mockCrypto)
+      .setPayload(jwtPayload)
+      .setProtectedHeader({ alg: 'RS512' /* any alg */ })
+      .signed();
+
+    const decoded = SignJWT.decode(signed);
+
+    expect(decoded.protectedHeader.alg).not.toEqual('RS512');
+  });
+
+  it.each`
+    key    | expected
+    ${pk0} | ${'ES256'}
+    ${pk1} | ${'RS256'}
+  `(
+    'it should select the right signing algorithm for the used key ($key.kid)',
+    async ({ key, expected }) => {
+      mockCrypto.getPublicKey.mockImplementationOnce(async () => key);
+      const signed = await new SignJWT(mockCrypto)
         .setPayload(jwtPayload)
-        .setProtectedHeader({ alg: 'invalid' })
-    ).toThrowError(JOSENotSupported);
-  });
-  it('it should fails without header', async () => {
-    expect(() => new SignJWT().setPayload(jwtPayload).toSign()).toThrowError(
-      JWSInvalid
-    );
-  });
+        .setProtectedHeader(jwtHeader)
+        .signed();
+
+      const decoded = SignJWT.decode(signed);
+
+      expect(decoded.protectedHeader.alg).toEqual(expected);
+    }
+  );
 });

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -18,7 +18,10 @@ const jwtHeader: CompactJWSHeaderParameters = {
 const signature =
   '6wA0M6rNYNSFN_EylzMA6ElAibW7FVSZyoLNEkHU5c_RKuiNenT08YIMvbysYautLZotUedEMP5xCyNpY34x6Q';
 
-let toSign = new SignJWT(jwtPayload).setProtectedHeader(jwtHeader).toSign();
+let toSign = new SignJWT()
+  .setPayload(jwtPayload)
+  .setProtectedHeader(jwtHeader)
+  .toSign();
 
 describe('Sign JWT', function () {
   it('it should be signed correctly', async () => {
@@ -29,10 +32,14 @@ describe('Sign JWT', function () {
   });
   it('it should fails with invalid alg', async () => {
     expect(() =>
-      new SignJWT(jwtPayload).setProtectedHeader({ alg: 'invalid' })
+      new SignJWT()
+        .setPayload(jwtPayload)
+        .setProtectedHeader({ alg: 'invalid' })
     ).toThrowError(JOSENotSupported);
   });
   it('it should fails without header', async () => {
-    expect(() => new SignJWT(jwtPayload).toSign()).toThrowError(JWSInvalid);
+    expect(() => new SignJWT().setPayload(jwtPayload).toSign()).toThrowError(
+      JWSInvalid
+    );
   });
 });

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -42,7 +42,7 @@ describe('Sign JWT', function () {
     const signedJwt = await new SignJWT(mockCrypto)
       .setPayload(jwtPayload)
       .setProtectedHeader(jwtHeader)
-      .signed();
+      .sign();
 
     expect(signedJwt).toBe(
       'eyJ0eXAiOiJqd3QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkZW1vIiwic3ViIjoiZGVtbyIsImlhdCI6MTY3NTIwNjAwMCwiZXhwIjoxNzA2NzQyMDAwfQ.6wA0M6rNYNSFN_EylzMA6ElAibW7FVSZyoLNEkHU5c_RKuiNenT08YIMvbysYautLZotUedEMP5xCyNpY34x6Q'
@@ -53,7 +53,7 @@ describe('Sign JWT', function () {
     const signed = await new SignJWT(mockCrypto)
       .setPayload(jwtPayload)
       .setProtectedHeader({ alg: 'RS512' /* any alg */ })
-      .signed();
+      .sign();
 
     const decoded = SignJWT.decode(signed);
 
@@ -71,7 +71,7 @@ describe('Sign JWT', function () {
       const signed = await new SignJWT(mockCrypto)
         .setPayload(jwtPayload)
         .setProtectedHeader(jwtHeader)
-        .signed();
+        .sign();
 
       const decoded = SignJWT.decode(signed);
 

--- a/src/__tests__/unsecured.test.ts
+++ b/src/__tests__/unsecured.test.ts
@@ -12,10 +12,35 @@ const jwtPayload: JWTPayload = {
 const encodedUnsecureJwt =
   'eyJhbGciOiJub25lIn0.eyJpc3MiOiJkZW1vIiwic3ViIjoiZGVtbyIsImlhdCI6MTY3NTIwNjAwMCwiZXhwIjoxNzA2NzQyMDAwfQ.';
 
+const encodedSecuredJwt =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTM4MTY4OTEsImV4cCI6MTcyNTM1Mjg5MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.27lkkQduvc_SCmOLzlF6wFhoiUh0eC9g-30MuBERqcI';
+const encodedJwtWithAlg =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTM4MTY4OTEsImV4cCI6MTcyNTM1Mjg5MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0';
+
 describe('Unsecured JWT', function () {
   it('it should be encoded correctly', async () => {
     const unsecured = new UnsecuredJWT().setPayload(jwtPayload).encode();
     expect(unsecured).toBe(encodedUnsecureJwt);
+  });
+  it('it should decode and unsecured jwt', async () => {
+    const result = UnsecuredJWT.decode(encodedUnsecureJwt);
+    expect(result).toEqual(
+      expect.objectContaining({
+        header: { alg: 'none' },
+        payload: expect.any(Object),
+      })
+    );
+  });
+  it('it should fail decoding a secured jwt', async () => {
+    expect(() => UnsecuredJWT.decode(encodedSecuredJwt)).toThrowError(
+      JWTInvalid
+    );
+  });
+
+  it('it should fail decoding an unsecured jwt with alg != none', async () => {
+    expect(() => UnsecuredJWT.decode(encodedJwtWithAlg)).toThrowError(
+      JWTInvalid
+    );
   });
   it('it should fail encoding with unknown payload', async () => {
     expect(() =>

--- a/src/__tests__/unsecured.test.ts
+++ b/src/__tests__/unsecured.test.ts
@@ -14,12 +14,12 @@ const encodedUnsecureJwt =
 
 describe('Unsecured JWT', function () {
   it('it should be encoded correctly', async () => {
-    const unsecured = new UnsecuredJWT(jwtPayload).encode();
+    const unsecured = new UnsecuredJWT().setPayload(jwtPayload).encode();
     expect(unsecured).toBe(encodedUnsecureJwt);
   });
   it('it should fail encoding with unknown payload', async () => {
     expect(() =>
-      new UnsecuredJWT('' as unknown as JWTPayload).encode()
+      new UnsecuredJWT().setPayload('' as unknown as JWTPayload).encode()
     ).toThrowError(TypeError);
   });
   it('it should be decoded correctly', async () => {

--- a/src/algorithms.ts
+++ b/src/algorithms.ts
@@ -31,49 +31,6 @@ export const getKtyFromAlg = (alg: string) => {
   }
 };
 
-/**
- * Given a key type, valdates if a signing algorithm is compatible
- *
- * @param kty The given key type
- * @param alg The signing algorithm
- *
- * @returns The provided algorithm in case it's compatible
- * @throws {JOSENotSupported} If the signing algorithm is not compatible with the provided key type
- */
-export const validateAlgFromKty = (
-  kty: string,
-  alg: string
-): SupportedAlgorithm => {
-  if (!isAlgSupported(alg)) {
-    throw new JOSENotSupported(`Unsupported algorithm ${alg}`);
-  }
-
-  const signatureAlg = alg.slice(0, 2);
-  const hashingAlg = alg.slice(2, 5);
-
-  const supportedHashes = ['256', '384', '512'];
-
-  if (!supportedHashes.includes(hashingAlg)) {
-    throw new JOSENotSupported(
-      `Unsupported hashing algorithm, expected one of {${supportedHashes.join(
-        ', '
-      )}}, received ${hashingAlg}`
-    );
-  }
-
-  if (
-    /* is valid for EC */ (kty === 'EC' && signatureAlg === 'ES') ||
-    /* OR is valid for RSA */ (kty === 'RSA' &&
-      ['RS', 'PS'].includes(signatureAlg))
-  ) {
-    return alg;
-  }
-
-  throw new JOSENotSupported(
-    `Unsupported "alg" value for a JSON Web Key Set. alg=${alg} is not compatible with kty=${kty}`
-  );
-};
-
 export const getAlgFromKey = ({ kty, alg, crv }: JWK): SupportedAlgorithm => {
   if (kty === 'RSA' && alg && isAlgSupported(alg)) {
     return alg;

--- a/src/algorithms.ts
+++ b/src/algorithms.ts
@@ -10,10 +10,11 @@ export const supportedAlgorithms = [
   'ES256',
   'ES384',
   'ES512',
-];
+] as const;
+export type SupportedAlgorithm = (typeof supportedAlgorithms)[number];
 
-export const isAlgSupported = (alg: string) =>
-  supportedAlgorithms.includes(alg.toUpperCase());
+export const isAlgSupported = (alg: string): alg is SupportedAlgorithm =>
+  (supportedAlgorithms as unknown as string[]).includes(alg.toUpperCase());
 
 export const getKtyFromAlg = (alg: string) => {
   switch (alg.slice(0, 2)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@ export {
   addPadding,
 } from './utils/base64';
 export { sha256ToBase64 } from './hash';
+export { type CryptoContext } from './utils/crypto';

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -4,14 +4,15 @@ import secs, { epoch } from '../utils/secs';
 
 /** Generic class for JWT producing. */
 export class ProduceJWT {
-  protected _payload!: JWTPayload;
+  protected _payload: JWTPayload = {};
 
   /** @param payload The JWT Claims Set object. */
-  constructor(payload: JWTPayload) {
+  setPayload(payload: JWTPayload) {
     if (!isObject(payload)) {
       throw new TypeError('JWT Claims Set MUST be an object');
     }
-    this._payload = payload;
+    this._payload = { ...this._payload, ...payload };
+    return this;
   }
 
   /**

--- a/src/jwt/sign.ts
+++ b/src/jwt/sign.ts
@@ -47,7 +47,7 @@ export class SignJWT extends ProduceJWT {
   }
 
   /**
-   * Return a JWT without signature (`header.payload`) to sign.
+   * Return a JWT w ithout signature (`header.payload`) to sign.
    *
    */
   toSign(): string {

--- a/src/jwt/sign.ts
+++ b/src/jwt/sign.ts
@@ -28,8 +28,7 @@ import type { CryptoContext } from 'src/utils/crypto';
  *   .setExpirationTime('2h')
  *
  * jwt.data()
- * await jwt.unsigned()
- * await jwt.signed()
+ * await jwt.sign()
  * ```
  */
 
@@ -61,7 +60,7 @@ export class SignJWT extends ProduceJWT {
    * Return a JWT without signature (`header.payload`).
    *
    */
-  async unsigned(): Promise<string> {
+  private async unsigned(): Promise<string> {
     const { alg } = await this.getSelectedSigningAlgorithm();
 
     return [{ ...this._protectedHeader, alg }, this._payload]
@@ -84,7 +83,7 @@ export class SignJWT extends ProduceJWT {
    * Return a signed JWT.
    *
    */
-  async signed(): Promise<string> {
+  async sign(): Promise<string> {
     const unsigned = await this.unsigned();
     const signature = await this.crypto.getSignature(unsigned);
 

--- a/src/jwt/unsecured.ts
+++ b/src/jwt/unsecured.ts
@@ -1,7 +1,7 @@
 import type {
-  JWSHeaderParameters,
   JWTClaimVerificationOptions,
   JWTPayload,
+  JoseHeaderParameters,
 } from '../types';
 
 import { JWTInvalid } from '../utils/errors';
@@ -11,7 +11,7 @@ import { decodeBase64, encodeBase64 } from '../utils/base64';
 
 export interface UnsecuredResult {
   payload: JWTPayload;
-  header: JWSHeaderParameters;
+  header: JoseHeaderParameters;
 }
 
 /**
@@ -86,18 +86,18 @@ export class UnsecuredJWT extends ProduceJWT {
       throw new JWTInvalid('Invalid Unsecured JWT');
     }
 
-    let header: JWSHeaderParameters;
+    let header: JoseHeaderParameters;
     try {
       let decoded = decodeBase64(encodedHeader!);
       header = JSON.parse(decoded);
-      if (header.alg !== 'none') throw new Error();
+      if ('alg' in header && header.alg !== 'none') throw new Error();
     } catch {
       throw new JWTInvalid('Invalid Unsecured JWT');
     }
 
     let payload = UnsecuredJWT.decodePayload(encodedPayload, options);
 
-    return { payload, header };
+    return { payload, header: JSON.parse(decodeBase64(encodedHeader!)) };
   }
 
   /**

--- a/src/jwt/unsecured.ts
+++ b/src/jwt/unsecured.ts
@@ -1,7 +1,7 @@
 import type {
   JWTClaimVerificationOptions,
   JWTPayload,
-  JoseHeaderParameters,
+  JWTUnsecuredHeaderParameters,
 } from '../types';
 
 import { JWTInvalid } from '../utils/errors';
@@ -11,7 +11,7 @@ import { decodeBase64, encodeBase64 } from '../utils/base64';
 
 export interface UnsecuredResult {
   payload: JWTPayload;
-  header: JoseHeaderParameters;
+  header: JWTUnsecuredHeaderParameters;
 }
 
 /**
@@ -86,7 +86,7 @@ export class UnsecuredJWT extends ProduceJWT {
       throw new JWTInvalid('Invalid Unsecured JWT');
     }
 
-    let header: JoseHeaderParameters;
+    let header: JWTUnsecuredHeaderParameters;
     try {
       let decoded = decodeBase64(encodedHeader!);
       header = JSON.parse(decoded);

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,10 +52,7 @@ export interface JWSHeaderParameters extends JoseHeaderParameters {
   /** Any other JWS Header member. */
   [propName: string]: unknown;
 }
-/** Recognized Compact JWS Header Parameters, any other Header Members may also be present. */
-export interface CompactJWSHeaderParameters extends JWSHeaderParameters {
-  alg: SupportedAlgorithm;
-}
+
 /** Recognized JWE Header Parameters, any other Header members may also be present. */
 export interface JWEHeaderParameters extends JoseHeaderParameters {
   /** JWE "alg" (Algorithm) Header Parameter. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { SupportedAlgorithm } from './algorithms';
 
 export interface JWTDecodeResult {
   /** JWT Claims Set. */
@@ -37,7 +38,7 @@ export interface JoseHeaderParameters {
 /** Recognized JWS Header Parameters, any other Header Members may also be present. */
 export interface JWSHeaderParameters extends JoseHeaderParameters {
   /** JWS "alg" (Algorithm) Header Parameter. */
-  alg?: string;
+  alg?: SupportedAlgorithm;
 
   /**
    * This JWS Extension Header Parameter modifies the JWS Payload representation and the JWS Signing
@@ -51,12 +52,10 @@ export interface JWSHeaderParameters extends JoseHeaderParameters {
   /** Any other JWS Header member. */
   [propName: string]: unknown;
 }
-
 /** Recognized Compact JWS Header Parameters, any other Header Members may also be present. */
 export interface CompactJWSHeaderParameters extends JWSHeaderParameters {
-  alg: string;
+  alg: SupportedAlgorithm;
 }
-
 /** Recognized JWE Header Parameters, any other Header members may also be present. */
 export interface JWEHeaderParameters extends JoseHeaderParameters {
   /** JWE "alg" (Algorithm) Header Parameter. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,11 @@ export interface JWSHeaderParameters extends JoseHeaderParameters {
   [propName: string]: unknown;
 }
 
+/** JOSE Header for an unsecued JWT */
+export interface JWTUnsecuredHeaderParameters extends JoseHeaderParameters {
+  alg?: 'none';
+}
+
 /** Recognized JWE Header Parameters, any other Header members may also be present. */
 export interface JWEHeaderParameters extends JoseHeaderParameters {
   /** JWE "alg" (Algorithm) Header Parameter. */

--- a/src/utils/asn1.ts
+++ b/src/utils/asn1.ts
@@ -1,4 +1,8 @@
-import { getCoordinateOctetLength, getKtyFromAlg } from '../algorithms';
+import {
+  getCoordinateOctetLength,
+  getKtyFromAlg,
+  type SupportedAlgorithm,
+} from '../algorithms';
 import { IoReactNativeJwt } from './proxy';
 import { removePadding } from './base64';
 import { JOSENotSupported } from './errors';
@@ -20,7 +24,7 @@ import { JOSENotSupported } from './errors';
  */
 export const derToJose = async (
   asn1Signature: string,
-  alg: string
+  alg: SupportedAlgorithm
 ): Promise<string> => {
   const kty = getKtyFromAlg(alg);
   if (kty === 'EC') {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,25 @@
+import type { JWK } from 'src/types';
+
+/**
+ * The interface of a cryptographic context to be used to sign tokens.
+ * Implementations are assumed to be initialized on a single, already-existing key pair.
+ *
+ * The generation and persistence of the key pair is delegated to the implementation.
+ */
+export interface CryptoContext {
+  /**
+   * Retrieves the public key to be used in this context.
+   * MUST be the same key at every invocation.
+   * @returns The public key to be used
+   * @throws If no keys are found
+   */
+  getPublicKey: () => Promise<JWK>;
+  /**
+   * Produce a cryptographic signature for a given value.
+   * The signature MUST be produced using the private key paired with the public retrieved by getPublicKey()
+   * @param value The value to be signed
+   * @returns The signature
+   * @throws If no keys are found
+   */
+  getSignature: (value: string) => Promise<string>;
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Added `setPayload` method to define JWT payload instead of passing data to class constructor
* Define `CryptoContext` interface to accept arbitrary, third-party implementations to handle cryptographic assets
* Define `SupportedAlgorithm` as type and guard
* `alg` attribute is no longer considered when a JWT is signed - it is inferred from the signing key instead
* Updated example app with the new interface

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Signed JWT must declare a `alg` attribute which is consistent with the key used to sign. Given that cryptographic assets are not handled by the current package, we decided so far to perform JWT production and signing in different stages (that is: we produce an unsigned JWT, then we ask the user to produce a signature, then we assemble the unsigned token and its signature).
Such implementation leaves the user with the duty to keep object consistent, hence there's no constraint in the interfaces that drives the user to do the right thing, hence we're are exposed to data inconsistency errors.

The proposed implementation aims to improve the behavior by handling the signing process itself, using a shared interface (`CryptoContext`) to interact with user-provided cryptography utilities.
The new interface is
```ts
const crypto: CryptoContext = userDefinedCryptoContext();
const signed = await new SignJWT(crypto)
      .setPayload({
        sub: 'demoApp',
        iss: 'PagoPa',
      })
      .setProtectedHeader({ typ: 'JWT' })
      .sign();
```

The `alg` attribute is then inferred from the signing key properties.
 


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Example app

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
