### PR TITLE
Removes platform check from podspec file.

### DIFF
--- a/pagopa-io-react-native-jwt.podspec
+++ b/pagopa-io-react-native-jwt.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/pagopa/io-react-native-jwt.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
## Short description

Removes platform check from podspec file.  `min_ios_version_supported` is an undefined local variable.

```
[!] Failed to load 'pagopa-io-react-native-jwt' podspec: 
[!] Invalid `pagopa-io-react-native-jwt.podspec` file: undefined local variable or method `min_ios_version_supported' for Pod:Module.

 #  from /path/to/consumer/project/node_modules/@pagopa/io-react-native-jwt/pagopa-io-react-native-jwt.podspec:14
 #  -------------------------------------------
 #  
 >    s.platforms    = { :ios => min_ios_version_supported }
 #    s.source       = { :git => "https://github.com/pagopa/io-react-native-jwt.git", :tag => "#{s.version}" }
 #  -------------------------------------------
```

I don't know what the intended minimum version would be so I have just removed it in the PR to draw this to your attention.  ~An alternative way to deal with this would be to define the variable with the intended minimum version.~  I think that the correct thing to do would be to specify a minimum react-native `peerDependency` that supports `min_ios_version_supported`.  (0.69+ ???)

## List of changes proposed in this pull request

Remove reference to `min_ios_version_supported`.

## How to test

Install the library, in a `react-native@0.67.x` project, and run `pod install` from the `ios` directory.
