### PR TITLE
fix: [WLEO-309] Add stronger null checking to iOS native bridge

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -210,6 +210,14 @@ export default function App() {
           title="Generate JWE (EC)"
           onPress={() => encryptPlaintextEcdh('hello', ecEncJwk)}
         />
+        <Button
+          title="Generate JWE (RSA) (WrongKey)"
+          onPress={() => encryptPlaintextRsa('hello', ecEncJwk)}
+        />
+        <Button
+          title="Generate JWE (EC) (WrongKey)"
+          onPress={() => encryptPlaintextEcdh('hello', encJwk)}
+        />
         <Button title="Verify with JWKSet" onPress={() => verifyWithJwks()} />
       </View>
       <View>

--- a/ios/IoReactNativeJwt.swift
+++ b/ios/IoReactNativeJwt.swift
@@ -200,7 +200,11 @@ class IoReactNativeJwt: NSObject {
                 if isECKey(jwk:jwk) {
                     // --- ECDH-ES / EC Key ---
                     let ecPublicKey = try ECPublicKey(data: publicKeyJson)
-                    let encrypter = Encrypter(keyManagementAlgorithm: try getKeyManagmentAlg(header: header), contentEncryptionAlgorithm: try getContentEncryptionAlgorithm(header: header), encryptionKey: ecPublicKey)!
+                    guard let encrypter = Encrypter(keyManagementAlgorithm: try getKeyManagmentAlg(header: header), contentEncryptionAlgorithm: try getContentEncryptionAlgorithm(header: header), encryptionKey: ecPublicKey)
+                    else {
+                      reject("Error", "Error creating Encrypter, incompatible key", nil)
+                      return
+                    }
                     
                     let jwe = try JWE(header: jweHeader, payload: payload, encrypter: encrypter)
 
@@ -208,7 +212,11 @@ class IoReactNativeJwt: NSObject {
                 } else {
                     let rsaJwk = try RSAPublicKey(data: publicKeyJson)
                     let publicKey = try rsaJwk.converted(to: SecKey.self)
-                    let encrypter = Encrypter(keyManagementAlgorithm: try getKeyManagmentAlg(header: header), contentEncryptionAlgorithm: try getContentEncryptionAlgorithm(header: header), encryptionKey: publicKey)!
+                    guard let encrypter = Encrypter(keyManagementAlgorithm: try getKeyManagmentAlg(header: header), contentEncryptionAlgorithm: try getContentEncryptionAlgorithm(header: header), encryptionKey: publicKey)
+                    else {
+                      reject("Error", "Error creating Encrypter, incompatible key", nil)
+                      return
+                    }
                     let jwe = try JWE(header: jweHeader, payload: payload, encrypter: encrypter)
 
                     resolve(jwe.compactSerializedString)


### PR DESCRIPTION
## Short description
This PR fixes [\[WLEO-309\]](https://pagopa.atlassian.net/jira/software/c/projects/WLEO/boards/601?assignee=712020%3Adcf931c4-2a77-403b-b539-7a018b6d504c&selectedIssue=WLEO-309) by adding early rejection in case of `nil` values inside the iOS native bridge.

## List of changes proposed in this pull request

- `ios/IoReactNativeJwt.swift` : Added `guard let` construct to `ios/IoReactNativeJwt.enc`'s `Encrypter` constructor invocations to reject and return early in case the constructor returns `nil` (which means a public key incompatible with the JWE header has been passed).
- `example/src/App.tsx` : Added test cases in which the encryption bridge is called with the wrong keys in both the EC and RSA cases, the expected result is that the applications shows an error alert.

## How to test

1. On an iOS device, open the example app.
2. Launch the _**Generate JWE (RSA) (Wrong key)**_ and _**Generate JWE (EC) (Wrong key)**_ actions, an error **should** appear and the application **should not** crash.