### PR TITLE
feat: [WLEO-444] Add A128GCM encryption support on iOS

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -125,11 +125,15 @@ export default function App() {
     jwe.then(setResult).catch(showError);
   };
 
-  const encryptPlaintextEcdh = (plaintext: String, encKey: JWK) => {
+  const encryptPlaintextEcdh = (
+    plaintext: String,
+    encKey: JWK,
+    enc: ConstructorParameters<typeof EncryptJwe>[1]['enc']
+  ) => {
     loading();
     const jwe = new EncryptJwe(plaintext, {
       alg: 'ECDH-ES',
-      enc: 'A256GCM',
+      enc,
     }).encrypt(encKey);
     jwe.then(setResult).catch(showError);
   };
@@ -207,8 +211,12 @@ export default function App() {
           onPress={() => encryptPlaintextRsa('hello', encJwk)}
         />
         <Button
-          title="Generate JWE (EC)"
-          onPress={() => encryptPlaintextEcdh('hello', ecEncJwk)}
+          title="Generate JWE (EC A256GCM)"
+          onPress={() => encryptPlaintextEcdh('hello', ecEncJwk, 'A256GCM')}
+        />
+        <Button
+          title="Generate JWE (EC A128GCM)"
+          onPress={() => encryptPlaintextEcdh('hello', ecEncJwk, 'A128GCM')}
         />
         <Button
           title="Generate JWE (RSA) (WrongKey)"
@@ -216,7 +224,7 @@ export default function App() {
         />
         <Button
           title="Generate JWE (EC) (WrongKey)"
-          onPress={() => encryptPlaintextEcdh('hello', encJwk)}
+          onPress={() => encryptPlaintextEcdh('hello', encJwk, 'A256GCM')}
         />
         <Button title="Verify with JWKSet" onPress={() => verifyWithJwks()} />
       </View>

--- a/ios/IoReactNativeJwt.swift
+++ b/ios/IoReactNativeJwt.swift
@@ -40,6 +40,8 @@ class IoReactNativeJwt: NSObject {
                 return ContentEncryptionAlgorithm.A256CBCHS512
             case "A256GCM":
                 return ContentEncryptionAlgorithm.A256GCM
+            case "A128GCM":
+              return ContentEncryptionAlgorithm.A128GCM
         default:
             throw HeaderError.invalidAlg("enc value not supported")
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,12 @@ export interface JWEHeaderParameters extends JoseHeaderParameters {
   alg?: 'RSA-OAEP-256' | 'RSA-OAEP' | 'ECDH-ES';
 
   /** JWE "enc" (Encryption Algorithm) Header Parameter. */
-  enc?: 'A256CBC-HS512' | 'A128CBC-HS256' | 'A128CBC-HS256' | 'A256GCM';
+  enc?:
+    | 'A256CBC-HS512'
+    | 'A128CBC-HS256'
+    | 'A128CBC-HS256'
+    | 'A256GCM'
+    | 'A128GCM';
 
   /** Any other JWE Header member. */
   [propName: string]: unknown;


### PR DESCRIPTION
## Short description
This PR adds support for `A128GCM` on iOS. On Android this is already supported and handled by the underlying native library, however on iOS there's an extra check on the `enc` value.
Include a summary of the changes.

## List of changes proposed in this pull request

- Add `A128GCM` in the typescript definition of the supported `enc` parameters; 
- Add `A128GCM` in the iOS `enc` parameter check to return the appropriate encrypter;
- Update the example app.

## How to test
Run the example app and press the button for the A128GCM encryption.
